### PR TITLE
Remove task to get list of unmaintained SLE pkgs

### DIFF
--- a/openSUSE-Leap.conf
+++ b/openSUSE-Leap.conf
@@ -1,6 +1,6 @@
 [project]
 name = openSUSE Leap 15.2
-
+identifier = opensuse-leap-15-2
 
 [ownership]
 markdown_variable = Responsible


### PR DESCRIPTION
* this task was not previuosly performed
* seems like it will loose it's values in Jump
  as every SLE package will overwrite Leap package unless it's tracked
here https://build.opensuse.org/project/show/openSUSE:Jump:15.2
  or there is a fork in openSUSE:Leap project.