### PR TITLE
Replace software-o-o with get-o-o

### DIFF
--- a/Alpha.md
+++ b/Alpha.md
@@ -50,13 +50,13 @@ Responsible: favogt
 * create openQA job group
 * sync to openQA
 * make obs publish to the correct directory
-* add to software.o.o
+* add to get.o.o
 
 #### clarify source code offer
 Responsible: rel-mgmt
 
 * clarify how long we need to provide the source
-* check if https://software.opensuse.org/distributions/leap not specifying methods is ok
+* check if https://get.opensuse.org/leap not specifying methods is ok
 * check https://en.opensuse.org/Source_code is current
 
 #### ask for scc enablement
@@ -240,12 +240,12 @@ for all packages that were added to Factory after the last leap release, set up 
 
 Make sure to talk to Bernhard to turn off the bug bot to avoid spamming bugzilla.
 
-#### prepare software.opensuse.org
+#### prepare get.opensuse.org
 Responsible: rel-mgmt
 
-prepare software.opensuse.org to show the testing distribution
+prepare get.opensuse.org to show the testing distribution
 
-https://github.com/openSUSE/software-o-o
+https://github.com/openSUSE/get-o-o
 
 #### verify betaversion in product files
 

--- a/GA.md
+++ b/GA.md
@@ -103,9 +103,9 @@ Organize release parties!
 
 The marketing/ambassador team can and should do this!
 
-#### software.opensuse.org
+#### get.opensuse.org
 
-Verify software.o.o has the correct data and links.
+Verify get.o.o has the correct data and links.
 Usually the -Current links are wrong.
 
 ##### translate release announcement

--- a/RC.md
+++ b/RC.md
@@ -141,13 +141,12 @@ There should be a way to do this by means of obs
 https://counter.opensuse.org/link/ should point to https://en.opensuse.org/Portal:15.1?pk_campaign=counter
 
 
-#### prepare software.opensuse.org
+#### prepare get.opensuse.org
 
-prepare software.opensuse.org for RC1
+prepare get.opensuse.org for RC1
 
-* https://github.com/openSUSE/software-o-o, app/controllers/main_controller.rb
-* Wait for package to build https://build.opensuse.org/package/show/openSUSE:infrastructure:software.opensuse.org/software_opensuse_org
-* Deploy when mirrors are ready
+* https://github.com/openSUSE/get-o-o, _data/releases.yml, _data/15X.yml
+* Sync with hellcp to deploy update when mirrors are ready
 
 #### EULA review/update
 


### PR DESCRIPTION
* Keep reference for software-o-o in the outdated template for press.
  Anything else related to sofware-o-o/distributions/* should already
  reference get-o-o instead